### PR TITLE
Exclude .idea/ for JetBrains IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -348,3 +348,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# JetBrains IDE's
+.idea/


### PR DESCRIPTION
To allow using JetBrains Rider as an alternative to Visual Studio.