### PR TITLE
Add theme styles to wpf preview

### DIFF
--- a/MostAwesomeDartApplicationEver/MostAwesomeDartApplicationEver/DesignTimeResources.xaml
+++ b/MostAwesomeDartApplicationEver/MostAwesomeDartApplicationEver/DesignTimeResources.xaml
@@ -1,0 +1,8 @@
+<ResourceDictionary
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:ui="http://schemas.modernwpf.com/2019">
+    <ResourceDictionary.MergedDictionaries>
+        <ui:IntellisenseResources Source="/ModernWpf;component/DesignTime/DesignTimeResources.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+</ResourceDictionary>

--- a/MostAwesomeDartApplicationEver/MostAwesomeDartApplicationEver/MostAwesomeDartApplicationEver.csproj
+++ b/MostAwesomeDartApplicationEver/MostAwesomeDartApplicationEver/MostAwesomeDartApplicationEver.csproj
@@ -23,4 +23,12 @@
     <None Include=".\.editorconfig" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Page Include="DesignTimeResources.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+      <ContainsDesignTimeResources>true</ContainsDesignTimeResources>
+    </Page>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
This makes designing easier as the preview now correctly shows margins, paddings and borders, among others.

Source: https://antonymale.co.uk/design-time-resources-in-wpf.html