### PR TITLE
Hack to avoid using DI implementation

### DIFF
--- a/MostAwesomeDartApplicationEver/MostAwesomeDartApplicationEver/App.xaml.cs
+++ b/MostAwesomeDartApplicationEver/MostAwesomeDartApplicationEver/App.xaml.cs
@@ -17,18 +17,22 @@ namespace MostAwesomeDartApplicationEver
     {
         private DartDbContext _context;
 
+        /// <summary>
+        /// Awful hack to avoid requiring DI and similar mess.
+        /// </summary>
+        internal static DartDbContext? Context { get; private set; }
+
         protected override void OnStartup(StartupEventArgs e)
         {
             base.OnStartup(e);
 
             MainWindow mainWin = new MainWindow();
 
-            _context = new DartDbContext();
+            Context = _context = new DartDbContext();
             _context.Database.EnsureCreated();
 
             ViewModels.DarterViewModel darterViewModel = new(_context);
             mainWin.DataContext = darterViewModel;
-            mainWin.NavigationFrame.Navigate(new Start());
             mainWin.Show();
         }
 
@@ -36,6 +40,7 @@ namespace MostAwesomeDartApplicationEver
         {
             base.OnExit(e);
             _context.Dispose();
+            Context = null;
         }
     }
 }

--- a/MostAwesomeDartApplicationEver/MostAwesomeDartApplicationEver/Views/MainWindow.xaml
+++ b/MostAwesomeDartApplicationEver/MostAwesomeDartApplicationEver/Views/MainWindow.xaml
@@ -15,5 +15,5 @@
             <c:CellEditEndingEventArgsConverter x:Key="CellEditEndingEventArgsConverter"/>
         </ResourceDictionary>
     </Window.Resources>
-    <Frame Name="NavigationFrame" NavigationUIVisibility="Hidden" />
+    <Frame Name="NavigationFrame" NavigationUIVisibility="Hidden" Source="Start.xaml"/>
 </Window>


### PR DESCRIPTION
Using App.Context to access the database is an awful hack, but beats making the application even more complex. Just call App.Context in the constructor of the ViewModel.